### PR TITLE
Update js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5188,9 +5188,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",


### PR DESCRIPTION
`npm audit` reported 7 vulnerabilities which can be fixed by updating js-yaml to version 3.13.1.